### PR TITLE
rename OVERFLOW (sometimes reserved) to OVERFLOWED

### DIFF
--- a/src/MiscTypes.h
+++ b/src/MiscTypes.h
@@ -64,6 +64,6 @@ struct EmptyCallback {
 enum class IsoNPduType { SINGLE_FRAME = 0, FIRST_FRAME = 1, CONSECUTIVE_FRAME = 2, FLOW_FRAME = 3 };
 
 /// FS field in Flow Control Frame
-enum class FlowStatus { CONTINUE_TO_SEND = 0, WAIT = 1, OVERFLOW = 2 };
+enum class FlowStatus { CONTINUE_TO_SEND = 0, WAIT = 1, OVERFLOWED = 2 };
 
 } // namespace tp

--- a/src/TransportProtocol.h
+++ b/src/TransportProtocol.h
@@ -579,7 +579,7 @@ template <typename TraitsT> bool TransportProtocol<TraitsT>::onCanNewFrame (cons
 
                 // 6.5.3.3 Error situation : too much data. Should reply with apropriate flow control frame.
                 if (multiFrameRemainingLen > MAX_ACCEPTED_ISO_MESSAGE_SIZE || multiFrameRemainingLen > MAX_ALLOWED_ISO_MESSAGE_SIZE) {
-                        sendFlowFrame (outgoingAddress, FlowStatus::OVERFLOW);
+                        sendFlowFrame (outgoingAddress, FlowStatus::OVERFLOWED);
                         return false;
                 }
 
@@ -830,12 +830,12 @@ template <typename TraitsT> Status TransportProtocol<TraitsT>::StateMachine::run
 
                 FlowStatus fs = Traits::getFlowStatus (*frame);
 
-                if (fs != FlowStatus::CONTINUE_TO_SEND && fs != FlowStatus::WAIT && fs != FlowStatus::OVERFLOW) {
+                if (fs != FlowStatus::CONTINUE_TO_SEND && fs != FlowStatus::WAIT && fs != FlowStatus::OVERFLOWED) {
                         tp.confirm (*theirAddress, Result::N_INVALID_FS); // 6.5.5.3
                         state = State::DONE;                              // abort
                 }
 
-                if (fs == FlowStatus::OVERFLOW) {
+                if (fs == FlowStatus::OVERFLOWED) {
                         tp.confirm (*theirAddress, Result::N_BUFFER_OVFLW);
                         state = State::DONE; // abort
                 }


### PR DESCRIPTION
math.h can define the preprocessor symbol 'OVERFLOW'.

In the past I've avoided #including math.h before this library to avoid the problem but this is error prone. I propose simply renaming the symbol used here to avoid the problem.

Excerpt of MacOSX 13.3 SDK math.h

 /Library/Developer/CommandLineTools/SDKs/MacOSX13.3.sdk/usr/include/math.h

```
   729	#if __DARWIN_C_LEVEL >= __DARWIN_C_FULL
   730	#define FP_SNAN		FP_NAN
   731	#define FP_QNAN		FP_NAN
   732	#define	HUGE		MAXFLOAT
   733	#define X_TLOSS		1.41484755040568800000e+16 
   734	#define	DOMAIN		1
   735	#define	SING		2
   736	#define	OVERFLOW	3              // <-----------
   737	#define	UNDERFLOW	4
   738	#define	TLOSS		5
   739	#define	PLOSS		6
```